### PR TITLE
#GitHubUniverse

### DIFF
--- a/.github/workflows/sobelow.yml
+++ b/.github/workflows/sobelow.yml
@@ -1,0 +1,41 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# Sobelow is a security-focused static analysis tool for the Phoenix framework. https://sobelow.io/
+#
+# To use this workflow, you must have GitHub Advanced Security (GHAS) enabled for your repository.
+#
+# Instructions:
+# 2. Follow the annotated workflow below and make any necessary modifications then save the workflow to your repository
+#    and review the "Security" tab once the action has run.
+name: Sobelow
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '29 4 * * 4'
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - id: run-action
+        uses: sobelow/action@1afd6d2cae70ae8bd900b58506f54487ed863912
+      - name: Upload report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Want pies to have that restaurant look? Egg wash is the key to making baked pastry a burnished bronze once it’s out of the oven – but there are ways to take it to the next level. Brush the pastry with egg wash, chill it for 10 minutes, then brush again – this double layer of eggy goodness will ensure an even, seriously golden finish. 
 
Cooking white fish? Sprinkle it liberally with flaky or rock salt and wait 15 minutes before washing it off, patting it dry and putting it in the pan. The salt draws out moisture, firming up the texture of the fish, and seasons it throughout.
 
Lined a tart tin with pastry, only to find there are a few holes? Instead of trying to patch it up with lumps of dough, resulting in an uneven finish, take a pea-size piece of pastry and mix it with a teaspoon of water until it turns into a thick paste. Use this pastry ‘glue’ to fill in any cracks or holes; as it bakes, it will melt and seamlessly form with the rest of the case.
 
Want to take garnishing with herbs to new heights? Infuse oil with them – it’s super simple and makes a standard salad look Michelin-starred. Just put a bunch of your chosen herbs (soft ones like basil, parsley, tarragon and dill work best) in a blender with an equal amount of vegetable oil. Whizz until smooth and bright green, then strain through a fine sieve. 
 
Hate peeling garlic? Separate the cloves, stick them in a lidded container and blast them in the microwave for 10-15 seconds. The heat will break the seal between garlic and peel, so after a quick bash with the flat of a knife the skins slip right off.
 
Dish tasting a little meh? Seasoning a dish with salt is important, but acidity always plays a significant role too. Half a teaspoon of vinegar in a tomato sauce, a scattering of quick-pickled onions or a squeeze of lemon or lime just before serving something can transform your meal from good to great.
 
Only need a squeeze of lemon juice? Don’t cut into a lemon if you only need a touch of juice – the rest of the fruit will dry out and usually end up being wasted. Instead, roll it back and forth with the palm of your hand to break up the cells inside, then use a skewer to make a small hole in one end. When squeezed it’ll provide a sprinkling of juice and will last up to 3 days in the fridge afterwards.
 
Roast veg a little limp? You’re probably overcrowding your baking tray. Always roast vegetables in a single layer, ideally with a good amount of space between each piece – two baking trays with plenty of space are always better than one overcrowded one. Tossing the vegetables with oil and seasoning them rather than just drizzling oil onto them will ensure they’re thoroughly coated, resulting in a much more even cook.